### PR TITLE
Add minimal DQN trading environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# TA3
+# Trading DQN Example
+
+This repository provides a minimal setup to train a Deep Q-Network (DQN) agent on OHLCV trading data.
+
+## Requirements
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Place your CSV file with columns `open`, `high`, `low`, `close`, and `volume` in a known location. Then run:
+
+```bash
+python train_dqn.py --data PATH_TO_YOUR_DATA.csv --episodes 100
+```
+
+The training script will print episode rewards and a simple evaluation score at the end.
+
+Hyperparameters such as learning rate, buffer size, and epsilon schedule can be modified via command-line arguments.

--- a/environment.py
+++ b/environment.py
@@ -1,0 +1,65 @@
+import gymnasium as gym
+import numpy as np
+import pandas as pd
+
+class TradingEnv(gym.Env):
+    """A simple trading environment for OHLCV data."""
+
+    metadata = {"render_modes": ["human"]}
+
+    def __init__(self, df: pd.DataFrame, window_size: int = 10, commission: float = 0.001):
+        super().__init__()
+        self.df = df.reset_index(drop=True)
+        self.window_size = window_size
+        self.commission = commission
+        self.current_step = window_size
+        self.position = 0  # 1 long, -1 short, 0 flat
+        self.cost_basis = 0.0
+        self.total_profit = 0.0
+
+        self.observation_space = gym.spaces.Box(
+            low=-np.inf,
+            high=np.inf,
+            shape=(window_size, df.shape[1]),
+            dtype=np.float32,
+        )
+        # Actions: 0 hold, 1 buy, 2 sell
+        self.action_space = gym.spaces.Discrete(3)
+
+    def reset(self, *, seed=None, options=None):
+        super().reset(seed=seed)
+        self.current_step = self.window_size
+        self.position = 0
+        self.cost_basis = 0.0
+        self.total_profit = 0.0
+        return self._get_observation(), {}
+
+    def step(self, action):
+        done = False
+        reward = 0.0
+        price = self.df.loc[self.current_step, "close"]
+        if action == 1 and self.position <= 0:  # buy
+            self.position = 1
+            self.cost_basis = price * (1 + self.commission)
+        elif action == 2 and self.position >= 0:  # sell
+            if self.position == 1:
+                reward = (price * (1 - self.commission) - self.cost_basis)
+                self.total_profit += reward
+            self.position = -1
+            self.cost_basis = price * (1 - self.commission)
+        # hold or invalid actions yield zero reward
+
+        self.current_step += 1
+        if self.current_step >= len(self.df) - 1:
+            done = True
+
+        obs = self._get_observation()
+        info = {"profit": self.total_profit}
+        return obs, reward, done, False, info
+
+    def _get_observation(self):
+        window = self.df.iloc[self.current_step - self.window_size : self.current_step]
+        return window.values.astype(np.float32)
+
+    def render(self):
+        pass

--- a/model.py
+++ b/model.py
@@ -1,0 +1,17 @@
+import torch
+import torch.nn as nn
+
+class DQN(nn.Module):
+    def __init__(self, input_dim: int, action_dim: int, hidden_dim: int = 64):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(input_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, action_dim),
+        )
+
+    def forward(self, x):
+        return self.net(x)

--- a/replay_buffer.py
+++ b/replay_buffer.py
@@ -1,0 +1,21 @@
+import random
+from collections import deque, namedtuple
+
+import numpy as np
+
+Transition = namedtuple('Transition', ('state', 'action', 'reward', 'next_state', 'done'))
+
+class ReplayBuffer:
+    def __init__(self, capacity: int):
+        self.buffer = deque(maxlen=capacity)
+
+    def __len__(self):
+        return len(self.buffer)
+
+    def push(self, *args):
+        self.buffer.append(Transition(*args))
+
+    def sample(self, batch_size: int):
+        samples = random.sample(self.buffer, batch_size)
+        batch = Transition(*zip(*samples))
+        return batch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+gymnasium
+pandas
+numpy
+torch

--- a/train_dqn.py
+++ b/train_dqn.py
@@ -1,0 +1,124 @@
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+from environment import TradingEnv
+from model import DQN
+from replay_buffer import ReplayBuffer
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Train a DQN trading agent")
+    parser.add_argument("--data", type=Path, required=True, help="Path to OHLCV CSV data")
+    parser.add_argument("--episodes", type=int, default=10)
+    parser.add_argument("--batch_size", type=int, default=32)
+    parser.add_argument("--buffer_size", type=int, default=10000)
+    parser.add_argument("--learning_rate", type=float, default=1e-3)
+    parser.add_argument("--gamma", type=float, default=0.99)
+    parser.add_argument("--epsilon_start", type=float, default=1.0)
+    parser.add_argument("--epsilon_end", type=float, default=0.01)
+    parser.add_argument("--epsilon_decay", type=int, default=500)
+    parser.add_argument("--target_update", type=int, default=10)
+    parser.add_argument("--window_size", type=int, default=10)
+    return parser.parse_args()
+
+
+def load_data(path: Path):
+    df = pd.read_csv(path)
+    required_cols = {"open", "high", "low", "close", "volume"}
+    if not required_cols.issubset(df.columns):
+        raise ValueError(f"CSV missing required columns: {required_cols}")
+    return df
+
+
+def select_action(state, policy_net, epsilon, action_space):
+    if np.random.rand() < epsilon:
+        return action_space.sample()
+    with torch.no_grad():
+        state_v = torch.from_numpy(state).unsqueeze(0)
+        q_values = policy_net(state_v)
+        return int(torch.argmax(q_values, dim=1).item())
+
+
+def compute_td_target(batch, policy_net, target_net, gamma):
+    state_batch = torch.tensor(np.array(batch.state))
+    action_batch = torch.tensor(batch.action)
+    reward_batch = torch.tensor(batch.reward)
+    next_state_batch = torch.tensor(np.array(batch.next_state))
+    done_batch = torch.tensor(batch.done, dtype=torch.float32)
+
+    q_values = policy_net(state_batch).gather(1, action_batch.unsqueeze(1)).squeeze()
+    with torch.no_grad():
+        next_q = target_net(next_state_batch).max(1).values
+    target = reward_batch + gamma * next_q * (1 - done_batch)
+    loss = nn.functional.mse_loss(q_values, target)
+    return loss
+
+
+def main():
+    args = parse_args()
+    df = load_data(args.data)
+
+    env = TradingEnv(df, window_size=args.window_size)
+    eval_env = TradingEnv(df, window_size=args.window_size)
+
+    obs_dim = env.observation_space.shape[0] * env.observation_space.shape[1]
+    n_actions = env.action_space.n
+
+    policy_net = DQN(obs_dim, n_actions)
+    target_net = DQN(obs_dim, n_actions)
+    target_net.load_state_dict(policy_net.state_dict())
+
+    optimizer = optim.Adam(policy_net.parameters(), lr=args.learning_rate)
+    replay_buffer = ReplayBuffer(args.buffer_size)
+
+    steps_done = 0
+    epsilon = args.epsilon_start
+
+    for ep in range(args.episodes):
+        state, _ = env.reset()
+        done = False
+        episode_reward = 0.0
+        while not done:
+            action = select_action(state, policy_net, epsilon, env.action_space)
+            next_state, reward, done, _, _ = env.step(action)
+            replay_buffer.push(state, action, reward, next_state, done)
+            state = next_state
+            episode_reward += reward
+            steps_done += 1
+            epsilon = args.epsilon_end + (args.epsilon_start - args.epsilon_end) * \
+                np.exp(-1.0 * steps_done / args.epsilon_decay)
+
+            if len(replay_buffer) >= args.batch_size:
+                batch = replay_buffer.sample(args.batch_size)
+                loss = compute_td_target(batch, policy_net, target_net, args.gamma)
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+
+            if ep % args.target_update == 0 and steps_done > 0:
+                target_net.load_state_dict(policy_net.state_dict())
+
+        print(f"Episode {ep}: reward={episode_reward:.2f}")
+
+    # Simple evaluation
+    state, _ = eval_env.reset()
+    done = False
+    total_reward = 0.0
+    while not done:
+        with torch.no_grad():
+            state_v = torch.from_numpy(state).unsqueeze(0)
+            action = int(torch.argmax(policy_net(state_v)))
+        next_state, reward, done, _, _ = eval_env.step(action)
+        total_reward += reward
+        state = next_state
+    print(f"Evaluation total reward: {total_reward:.2f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a simple Gym trading environment
- implement replay buffer and DQN model
- create training script with epsilon-greedy and target network updates
- document usage in README
- add requirements file

## Testing
- `python -m py_compile environment.py replay_buffer.py model.py train_dqn.py`
- `pip install numpy pandas torch gymnasium` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_6847191e0608832d8ecf57d1eb775165